### PR TITLE
- corrected a bug when an AMI image or a snapshot has empty tags which l...

### DIFF
--- a/distami/core.py
+++ b/distami/core.py
@@ -130,13 +130,20 @@ class Distami(object):
         
         # Copy AMI tags to new AMI
         log.info('Copying tags to %s in %s', copied_ami_id, region)
-        dest_conn.create_tags(copied_ami_id, self._image.tags)
+        if self._image.tags:
+            dest_conn.create_tags(copied_ami_id, self._image.tags)
+        else:
+            log.info('AMI tags empty, nothing to copy')
         
         # Also copy snapshot tags to new snapshot
         copied_snapshot_id = copied_image.block_device_mapping['/dev/sda1'].snapshot_id
         snapshot = utils.get_snapshot(self._conn, self._snapshot_id)
         log.info('Copying tags to %s in %s', copied_snapshot_id, region)
-        dest_conn.create_tags(copied_snapshot_id, snapshot.tags)
+
+        if snapshot.tags:
+            dest_conn.create_tags(copied_snapshot_id, snapshot.tags)
+        else:
+            log.info('Snapshot tags empty, nothing to copy')
 
         log.info('Copy to %s complete', region)
         return copied_ami_id


### PR DESCRIPTION
# Description:

I found out that the routine copy_to_region of Distami class throws an exception when AMI image or snapshot has empty tags. The pull requests contain simple "tags dict is empty" check to get rid of this misbehavior.
# Tested on:

boto (2.27.0)
# Exception details:

2014-04-11 16:34:02 [INFO] Looking for AMI ami-46ff1f31 in region eu-west-1
2014-04-11 16:34:03 [INFO] Found AMI ami-46ff1f31 with snapshot snap-2d46d133
2014-04-11 16:34:03 [INFO] Copying AMI to us-east-1
2014-04-11 16:34:05 [INFO] ami-996e71f0 in us-east-1 not available, waiting...
2014-04-11 16:34:36 [INFO] ami-996e71f0 in us-east-1 not available, waiting...
2014-04-11 16:35:07 [INFO] ami-996e71f0 in us-east-1 not available, waiting...
2014-04-11 16:35:38 [INFO] ami-996e71f0 in us-east-1 not available, waiting...
2014-04-11 16:36:09 [INFO] ami-996e71f0 in us-east-1 not available, waiting...
2014-04-11 16:36:41 [INFO] ami-996e71f0 in us-east-1 not available, waiting...
2014-04-11 16:37:12 [INFO] ami-996e71f0 in us-east-1 not available, waiting...
2014-04-11 16:37:43 [INFO] ami-996e71f0 in us-east-1 not available, waiting...
2014-04-11 16:38:14 [INFO] ami-996e71f0 in us-east-1 not available, waiting...
2014-04-11 16:38:45 [INFO] ami-996e71f0 in us-east-1 not available, waiting...
2014-04-11 16:39:16 [INFO] ami-996e71f0 in us-east-1 not available, waiting...
2014-04-11 16:39:47 [INFO] Copying tags to ami-996e71f0 in us-east-1
Traceback (most recent call last):
  File "/home/ec2-user/python_virt/bin/distami", line 8, in <module>
    load_entry_point('distami==1.0.5', 'console_scripts', 'distami')()
  File "/home/ec2-user/python_virt/lib/python2.7/site-packages/distami/cli.py", line 132, in run
    copy([distami, region, args])
  File "/home/ec2-user/python_virt/lib/python2.7/site-packages/distami/cli.py", line 43, in copy
    copied_ami_id = distami.copy_to_region(to_region)
  File "/home/ec2-user/python_virt/lib/python2.7/site-packages/distami/core.py", line 133, in copy_to_region
    dest_conn.create_tags(copied_ami_id, self._image.tags)
  File "/home/ec2-user/python_virt/lib/python2.7/site-packages/boto/ec2/connection.py", line 4154, in create_tags
    return self.get_status('CreateTags', params, verb='POST')
  File "/home/ec2-user/python_virt/lib/python2.7/site-packages/boto/connection.py", line 1196, in get_status
    raise self.ResponseError(response.status, response.reason, body)
boto.exception.EC2ResponseError: EC2ResponseError: 400 Bad Request
<?xml version="1.0" encoding="UTF-8"?>
<Response><Errors><Error><Code>InvalidParameterValue</Code><Message>You must specify one or more tags to create</Message></Error></Errors><RequestID>285af204-43c8-4270-adf6-9f9218b639b4</RequestID></Response>
