### PR TITLE
Fix sharing option

### DIFF
--- a/distami/cli.py
+++ b/distami/cli.py
@@ -51,7 +51,8 @@ def copy(param_array):
         ami_cp.make_snapshot_public()
 
     if args.accounts:
-        distami.share_ami_with_accounts(args.accounts)
+        ami_cp.share_ami_with_accounts(args.accounts)
+        ami_cp.share_snapshot_with_accounts(args.accounts)
     
 
 def run():


### PR DESCRIPTION
by calling the right object (ami_cp) and don't forget sharing the snapshot too.