### PR TITLE
Fix copy for multi-account/regions case

### DIFF
--- a/distami/__init__.py
+++ b/distami/__init__.py
@@ -13,4 +13,4 @@
 # limitations under the License.
 
 __author__ = 'Peter Sankauskas'
-__version__ = '1.0.7'
+__version__ = '1.0.8'

--- a/distami/cli.py
+++ b/distami/cli.py
@@ -51,8 +51,9 @@ def copy(param_array):
         ami_cp.make_snapshot_public()
 
     if args.accounts:
-        ami_cp.share_ami_with_accounts(args.accounts)
-        ami_cp.share_snapshot_with_accounts(args.accounts)
+        account_ids = args.accounts.split(',')
+        ami_cp.share_ami_with_accounts(account_ids)
+        ami_cp.share_snapshot_with_accounts(account_ids)
     
 
 def run():

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -16,8 +16,11 @@ import unittest
 
 from distami import utils
 
+
 class UtilTests(unittest.TestCase):
     def test_get_regions_to_copy_to(self):
-        all_public_regions = ['ap-southeast-1', 'ap-southeast-2', 'ap-northeast-1', 'us-east-1', 'us-west-1', 'us-west-2', 'sa-east-1', 'eu-west-1', 'eu-central-1']
+        all_public_regions = ['ap-south-1', 'ap-southeast-1', 'ap-southeast-2', 'ap-northeast-1', 'ap-northeast-2', 'us-east-1', 'us-west-1',
+                              'us-west-2', 'sa-east-1', 'eu-west-1', 'eu-central-1']
         regions = utils.get_regions_to_copy_to('not-a-real-region')
+        print 'regions: ', regions, ', all_public_regions: ', all_public_regions
         self.assertItemsEqual(regions, all_public_regions)


### PR DESCRIPTION
distami was failing with the following error running with multiple accounts/regiond:
```
distami ami-12345678 --accounts=111111111111,222222222222 --non-public -v --to us-east-1,ap-northeast-1 -v -p
```

was failing with an error like a one below:
```
2016-10-11 00:33:40 [INFO] Sharing AMI ami-12345678 with AWS Accounts 111111111111,222222222222
Traceback (most recent call last):
  File "/usr/local/bin/distami", line 9, in <module>
    load_entry_point('distami==1.0.7', 'console_scripts', 'distami')()
  File "/usr/local/lib/python2.7/dist-packages/distami/cli.py", line 132, in run
    copy([distami, region, args])
  File "/usr/local/lib/python2.7/dist-packages/distami/cli.py", line 54, in copy
    distami.share_ami_with_accounts(args.accounts)
  File "/usr/local/lib/python2.7/dist-packages/distami/core.py", line 87, in share_ami_with_accounts
    res = self._image.set_launch_permissions(user_ids=account_ids)
  File "/usr/local/lib/python2.7/dist-packages/boto/ec2/image.py", line 353, in set_launch_permissions
    dry_run=dry_run)
  File "/usr/local/lib/python2.7/dist-packages/boto/ec2/connection.py", line 519, in modify_image_attribute
    return self.get_status('ModifyImageAttribute', params, verb='POST')
  File "/usr/local/lib/python2.7/dist-packages/boto/connection.py", line 1226, in get_status
    raise self.ResponseError(response.status, response.reason, body)
boto.exception.EC2ResponseError: EC2ResponseError: 400 Bad Request
<?xml version="1.0" encoding="UTF-8"?>
<Response><Errors><Error><Code>InvalidAMIAttributeItemValue</Code><Message>Invalid attribute item value "111111111111,222222222222 " for userId item type.</Message></Error></Errors><RequestID><REDACTED></RequestID></Response>
```

Minor changes: Updated zones in unittests to reflect new zones introduced by AWS